### PR TITLE
feat: add executable matrix file

### DIFF
--- a/matrix
+++ b/matrix
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+init_term() {
+    printf '\e[?1049h\e[2J\e[?25l'
+    if [ "${BASH_VERSINFO[0]:-0}" -le 3 ]; then
+        read -r LINES COLUMNS < <(stty size)
+    else
+        shopt -s checkwinsize
+        # Force a command to update LINES/COLUMNS
+        (:)
+    fi
+}
+
+deinit_term() { 
+    # Kill all background jobs
+    jobs -p | xargs -r kill 2>/dev/null || true
+    printf '\e[?1049l\e[?25h'
+    stty echo
+}
+
+print_to() {
+    printf '\e[%d;%dH\e[32m%s\e[0m' "$2" "$3" "$1"
+}
+
+rain() {
+    local dropStart dropCol dropLen dropSpeed dropColDim color symbol i
+    
+    ((dropStart = RANDOM % (LINES / 9 + 1)))
+    ((dropCol = RANDOM % COLUMNS + 1))
+    ((dropLen = RANDOM % (LINES * 3/4) + 10))
+    ((dropSpeed = RANDOM % 9 + 1))
+    ((dropColDim = RANDOM % 4))
+    
+    color="${COLORS[RANDOM % ${#COLORS[@]}]}"
+    
+    for ((i = dropStart; i <= LINES + dropLen; i++)); do
+        symbol="${1:$((RANDOM % ${#1})):1}"
+        
+        # Draw bright character at current position
+        if ((dropColDim == 0)) && ((i <= LINES)); then
+            print_to "$symbol" "$i" "$dropCol"
+        fi
+        
+        # Draw normal character at previous position
+        if ((i > dropStart)) && ((i - 1 <= LINES)); then
+            print_to "$symbol" "$((i-1))" "$dropCol"
+        fi
+        
+        # Clear tail
+        if ((i > dropLen)) && ((i - dropLen <= LINES)); then
+            printf '\e[%d;%dH ' "$((i - dropLen))" "$dropCol"
+        fi
+        
+        sleep "0.0$dropSpeed"
+    done
+}
+
+cleanup() {
+    deinit_term
+    exit 0
+}
+
+trap cleanup EXIT INT TERM
+trap 'init_term' WINCH
+
+# Use a mix of characters for better compatibility
+SYMBOLS='アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789!@#$%^&*()-_=+[]{}|;:,.<>?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+COLORS=('102;255;102')
+
+matrix() {
+    if ! init_term; then
+        printf 'Failed initializing terminal\n' >&2
+        return 1
+    fi
+    stty -echo
+    
+    local max_jobs=$((COLUMNS / 2))
+    
+    while true; do
+        # Launch new raindrops
+        for ((j = 0; j < 3; j++)); do
+            rain "$SYMBOLS" &
+        done
+        
+        # Simple job control to prevent too many background processes
+        while (($(jobs -r | wc -l) > max_jobs)); do
+            sleep 0.05
+        done
+        
+        sleep 0.1
+    done
+}
+
+matrix


### PR DESCRIPTION
This pull request introduces a new `matrix` script that creates a terminal-based "Matrix rain" animation. The script is written in Bash and includes features for terminal initialization, raindrop rendering, and cleanup upon exit.

### Key Features of the `matrix` Script:

**Terminal Initialization and Cleanup:**
* Added `init_term` function to configure the terminal for the animation, including switching to an alternate screen, hiding the cursor, and handling terminal size updates. (`[matrixR1-R95](diffhunk://#diff-6e00cd562cc2d88e238dfb81d9439de7ec843ee9d0c9879d549cb1436786f975R1-R95)`)
* Added `deinit_term` function to restore the terminal to its original state, show the cursor, and clean up background jobs upon script exit. (`[matrixR1-R95](diffhunk://#diff-6e00cd562cc2d88e238dfb81d9439de7ec843ee9d0c9879d549cb1436786f975R1-R95)`)

**Matrix Rain Animation:**
* Implemented `rain` function to simulate falling characters ("raindrops") with randomized positions, lengths, speeds, and colors. (`[matrixR1-R95](diffhunk://#diff-6e00cd562cc2d88e238dfb81d9439de7ec843ee9d0c9879d549cb1436786f975R1-R95)`)
* Introduced `SYMBOLS` and `COLORS` variables to define the character set and color scheme for the animation. (`[matrixR1-R95](diffhunk://#diff-6e00cd562cc2d88e238dfb81d9439de7ec843ee9d0c9879d549cb1436786f975R1-R95)`)

**Script Execution and Job Control:**
* Added a main `matrix` function to manage the animation loop, spawn raindrops as background jobs, and limit the number of concurrent jobs to optimize performance. (`[matrixR1-R95](diffhunk://#diff-6e00cd562cc2d88e238dfb81d9439de7ec843ee9d0c9879d549cb1436786f975R1-R95)`)
* Included signal traps for cleanup on script termination (`EXIT`, `INT`, `TERM`) and reinitialization on window resize (`WINCH`). (`